### PR TITLE
feat: add an imports reader and `__all__` fixer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,12 @@ jobs:
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@stable
 
+    - name: Run rustfmt
+      run: cargo fmt -- --check
+
+    - name: Run clippy
+      run: cargo clippy -- -D warnings
+
     - name: Build
       run: cargo build --verbose
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,11 +7,11 @@ use walkdir::WalkDir;
 
 const IMPORT_PATTERNS: [&str; 3] = [
     // import module
-    r"import\s[a-z]+(\.[a-z]+)*(?:\sas\s[a-z]+)?",
+    r"(import\s[\w]+(\.[\w]+)*(\sas\s[\w]+)?)",
     // from mod(.submod...) import submodule (as alias)
-    r"from\s[a-z]+(\.[a-z]+)*\simport\s[a-z]+(?:\sas\s[a-z]+)?",
+    r"from\s[\w]+(\.[\w]+)*\simport\s[\w]+(?:\sas\s[\w]+)?",
     // from mod(.submod...) import {submod1, submod2, ...} on multiple lines,
-    r"from\s+[a-z]+(?:\.[a-z]+)*\s+import\s+\{[^}]*\}",
+    r"from\s+[\w]+(?:\.[\w]+)*\s+import\s+\{[^}]*\}",
 ];
 
 #[derive(Parser, Debug)]
@@ -147,6 +147,7 @@ fn remove_main_and_all_blocks(lines: Vec<String>) -> Vec<String> {
         } else if inside_all_block
             && !line.starts_with("    ")
             && !line.starts_with('\t')
+            && !line.starts_with(']')
             && !line.trim().is_empty()
         {
             inside_all_block = false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,14 @@ use std::fs;
 use std::io::{self, BufRead, Write};
 use walkdir::WalkDir;
 
+const IMPORT_PATTERNS: [&str; 3] = [
+    // import module
+    r"import\s[a-z]+(\.[a-z]+)*(?:\sas\s[a-z]+)?",
+    // from mod(.submod...) import submodule (as alias)
+    r"from\s[a-z]+(\.[a-z]+)*\simport\s[a-z]+(?:\sas\s[a-z]+)?",
+    // from mod(.submod...) import {submod1, submod2, ...} on multiple lines,
+    r"from\s+[a-z]+(?:\.[a-z]+)*\s+import\s+\{[^}]*\}",
+];
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -30,12 +38,10 @@ impl PyImports {
                 "import" => {
                     // Check if import module as alias. If so, add the alias to the attributes.
                     let module = parts.next().unwrap();
-                    if module.contains("as") {
-                        let _ = parts.next(); // Skip the "as" part.
-                        let alias = parts.next().unwrap();
-                        attributes.push(alias.to_string());
-                    } else if module.contains(".") {
-                        let parts: Vec<&str> = module.split(".").collect();
+                    if parts.clone().count() > 1 {
+                        attributes.push(parts.clone().last().unwrap().to_string());
+                    } else if module.contains('.') {
+                        let parts: Vec<&str> = module.split('.').collect();
                         attributes.push(parts[parts.len() - 1].to_string());
                     } else {
                         attributes.push(module.to_string());
@@ -45,10 +51,15 @@ impl PyImports {
                     let _ = parts.next(); // Skip the module name.
                     let _ = parts.next(); // Skip the "import" part.
                     for part in parts {
-                        if part.ends_with(",") {
-                            attributes.push(part[..part.len() - 1].to_string());
-                        } else {
-                            attributes.push(part.to_string());
+                        if part != "{" && part != "}" {
+                            if part == "as" {
+                                // Remove the last added attribute to add the alias later.
+                                attributes.pop();
+                            } else if let Some(p) = part.strip_suffix(',') {
+                                attributes.push(p.to_string());
+                            } else {
+                                attributes.push(part.to_string());
+                            }
                         }
                     }
                 }
@@ -60,34 +71,27 @@ impl PyImports {
     }
 }
 
-fn prepare_import_list(lines: Vec<String>) -> Vec<String> {
-    let mut import_lines = Vec::new();
-    let mut multiline_imports = Vec::new();
-    let mut in_multiline_import = false;
+fn prepare_import_list(path: &str) -> Vec<String> {
+    // Use regex to match all the import statements.
+    let mut imports = Vec::new();
+    let data = fs::read_to_string(path).unwrap();
 
-    for line in lines {
-        if line.starts_with("import") {
-            import_lines.push(line);
-        } else if line.starts_with("from") {
-            // Check if line ends with { which means it is a multiline import.
-            if line.ends_with("{") {
-                multiline_imports.push(line);
-                in_multiline_import = true;
-            } else {
-                import_lines.push(line);
-            }
-        } else if in_multiline_import {
-            if line.ends_with("}") {
-                multiline_imports.push(line);
-                in_multiline_import = false;
-                import_lines.push(multiline_imports.join(" "));
-                multiline_imports.clear();
-            } else {
-                multiline_imports.push(line);
-            }
+    let whitespace_re = regex::Regex::new(r"\s+").unwrap();
+    for pattern in IMPORT_PATTERNS.iter() {
+        let re = regex::Regex::new(pattern).unwrap();
+        for cap in re.captures_iter(&data) {
+            let import_block = &cap[0];
+
+            let cleaned_import_block = whitespace_re
+                .replace_all(import_block, " ")
+                .to_string()
+                .trim()
+                .to_string();
+
+            imports.push(cleaned_import_block);
         }
     }
-    import_lines
+    imports
 }
 
 fn remove_main_block(lines: Vec<String>) -> Vec<String> {
@@ -96,22 +100,40 @@ fn remove_main_block(lines: Vec<String>) -> Vec<String> {
 
     for line in lines {
         if line.trim_start().starts_with("if __name__ == '__main__':")
-            || line.trim_start().starts_with("if __name__ == \"__main__\":") {
-                inside_main_block = true;
-            } else if inside_main_block
-                && !line.starts_with("    ")
-                && !line.starts_with("\t")
-                && !line.trim().is_empty() {
-                    inside_main_block = false;
-                    cleaned_lines.push(line);
-            } else if !inside_main_block {
-                cleaned_lines.push(line);
-            }
+            || line
+                .trim_start()
+                .starts_with("if __name__ == \"__main__\":")
+        {
+            inside_main_block = true;
+        } else if inside_main_block
+            && !line.starts_with("    ")
+            && !line.starts_with('\t')
+            && !line.trim().is_empty()
+        {
+            inside_main_block = false;
+            cleaned_lines.push(line);
+        } else if !inside_main_block {
+            cleaned_lines.push(line);
+        }
     }
 
     cleaned_lines
 }
 
+/// Clean the file by applying the following steps:
+/// 1. Remove the __main__ block.
+/// 2. Fix the imports and the __all__ variable.
+/// 3. Write the cleaned lines back to the file.
+///
+/// # Arguments
+/// * `path` - The path to the file to clean.
+///
+/// # Returns
+/// An io::Result<()> indicating the success of the operation.
+///
+/// # Errors
+/// If the file cannot be opened or written to.
+///
 fn clean_file(path: &str) -> io::Result<()> {
     let file = fs::File::open(path)?;
     let reader = io::BufReader::new(file);
@@ -121,16 +143,13 @@ fn clean_file(path: &str) -> io::Result<()> {
     // Run remove_main_block
     let cleaned_lines = remove_main_block(lines);
     // Fix imports
-    let prepared_imports = prepare_import_list(cleaned_lines.clone());
-    println!("{:?}", prepared_imports);
-    let pyimports = PyImports::from_list_of_strings(prepared_imports);
-    println!("{:?}", pyimports.attributes);
+    let prepared_imports = prepare_import_list(path);
+    let _ = PyImports::from_list_of_strings(prepared_imports);
 
     let mut file = fs::File::create(path)?;
     for line in cleaned_lines {
         writeln!(file, "{}", line)?;
     }
-
     Ok(())
 }
 
@@ -138,7 +157,7 @@ fn main() {
     let args = Args::parse();
     let dir = args.dir;
 
-    for entry in WalkDir::new(&dir).into_iter().filter_map(|e| e.ok()) {
+    for entry in WalkDir::new(dir).into_iter().filter_map(|e| e.ok()) {
         let path = entry.path().display().to_string();
         if path.ends_with("__init__.py") {
             clean_file(&path).unwrap();
@@ -166,7 +185,18 @@ mod tests {
         let pyimports = PyImports::from_list_of_strings(lines);
         assert_eq!(
             pyimports.attributes,
-            vec!["datetime", "pd", "nn", "nn", "nn", "ndarray", "DataFrame", "Series", "String", "Int8"]
+            vec![
+                "datetime",
+                "pd",
+                "nn",
+                "nn",
+                "nn",
+                "ndarray",
+                "DataFrame",
+                "Series",
+                "String",
+                "Int8"
+            ]
         );
     }
 
@@ -177,7 +207,8 @@ mod tests {
 
         let content = r#"
 import pandas as pd
-from torch import { 
+import torch.data
+from torch import {
     nn,
     functional as F,
 }
@@ -212,16 +243,17 @@ df = pl.DataFrame({
 })
 "#;
 
-    let mut file = fs::File::create(&file_path).unwrap();
-    writeln!(file, "{}", content).unwrap();
+        let mut file = fs::File::create(&file_path).unwrap();
+        writeln!(file, "{}", content).unwrap();
 
-    let _path = file_path.to_str().unwrap();
-    clean_file(_path).unwrap();
+        let _path = file_path.to_str().unwrap();
+        clean_file(_path).unwrap();
 
-    let modified_content = fs::read_to_string(&file_path).unwrap();
-    let expected_content = r#"
+        let modified_content = fs::read_to_string(&file_path).unwrap();
+        let expected_content = r#"
 import pandas as pd
-from torch import { 
+import torch.data
+from torch import {
     nn,
     functional as F,
 }
@@ -249,7 +281,7 @@ df = pl.DataFrame({
 
 "#;
 
-    assert_eq!(modified_content, expected_content);
-    dir.close().unwrap();
+        assert_eq!(modified_content, expected_content);
+        dir.close().unwrap();
     }
 }


### PR DESCRIPTION
This PR adds code to check the imports of all `__init__.py` files and check if everything is exported in an `__all__` statement.

* [x] Extract import lines
* [x] Prepare attributes from import lines
* [x] Create `__all__` statement from imports
* [x] Append the `__all__` statement at the end of the file